### PR TITLE
kerberos keytab access fix

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -6,4 +6,5 @@ RUN yum -y --setopt skip_missing_names_on_install=False \
 WORKDIR /opt/app-root/src
 COPY requirements.txt ./
 RUN pip3 install -r requirements.txt
+COPY conf/krb5-redhat.conf /etc/krb5.conf
 EXPOSE 8080

--- a/Dockerfile.update
+++ b/Dockerfile.update
@@ -3,5 +3,4 @@ COPY . .
 RUN pip3 install -r requirements.txt
 RUN python3 manage.py migrate
 RUN echo "$(echo '00 06 * * * sh ./cron_jobs/data_import.sh' ; crontab -l)" | crontab -
-COPY conf/krb5-redhat.conf /etc/krb5.conf
 CMD ["python3", "manage.py", "runserver", "0.0.0.0:8080", "--noreload"]

--- a/Dockerfile.update
+++ b/Dockerfile.update
@@ -3,4 +3,5 @@ COPY . .
 RUN pip3 install -r requirements.txt
 RUN python3 manage.py migrate
 RUN echo "$(echo '00 06 * * * sh ./cron_jobs/data_import.sh' ; crontab -l)" | crontab -
+COPY conf/krb5-redhat.conf /etc/krb5.conf
 CMD ["python3", "manage.py", "runserver", "0.0.0.0:8080", "--noreload"]

--- a/conf/krb5-redhat.conf
+++ b/conf/krb5-redhat.conf
@@ -1,0 +1,20 @@
+includedir /etc/krb5.conf.d/
+
+[logging]
+    default = FILE:/var/log/krb5libs.log
+    kdc = FILE:/var/log/krb5kdc.log
+    admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+default_realm = REDHAT.COM
+dns_lookup_realm = true
+dns_lookup_kdc = true
+rdns = false
+dns_canonicalize_hostname = true
+ticket_lifetime = 24h
+forwardable = true
+udp_preference_limit = 0
+# Workaround for running `kinit` in an unprivileged container
+# by storing krb5 credential cache into a file rather than kernel keyring.
+# See https://blog.tomecek.net/post/kerberos-in-a-container/
+default_ccache_name = FILE:/tmp/krb5cc_%{uid}


### PR DESCRIPTION
The kerberos configuration was outdated, therefore art-dash could not access errata. Thats why the front page was not getting back any content. art-dash uses the read-only mounted keytab to `kinit`. The credentials will be stored in the default kerberos location` /tmp/krb5cc_<id>`. 