### PR TITLE
Update advisory json, partial filter

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -24,7 +24,7 @@ class UserFilter(django_filters.FilterSet):
             "dg_commit": ["icontains", "exact"],
             "label_io_openshift_build_commit_id": ["icontains", "exact"],
             "time_iso": ["exact"],
-            "jenkins_build_number": ["icontains", "exact"],
+            "jenkins_build_url": ["icontains", "exact"],
         }
 
 

--- a/lib/http_requests.py
+++ b/lib/http_requests.py
@@ -173,5 +173,5 @@ def get_branch_advisory_ids(branch_name):
     advisories = get_advisories(branch_name)
 
     if advisories:
-        return {"current": advisories[0][-1], "previous": advisories[1][-1]}
+        return {advisories[0][0]: advisories[0][-1], advisories[1][0]: advisories[1][-1]}
     return {"current": {}, "previous": {}}


### PR DESCRIPTION
Update the format in which advisories are sent to the front end. 'Current' and 'Previous' are now replaced with the exact versions. Jenkins build field changed to url field.