### PR TITLE
Document the rpms-images-fetcher Endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -162,3 +162,30 @@ Response:
   "payload": "Setup successful"
 }
 ```
+
+### GET /api/v1/rpms-images-fetcher
+
+This endpoint fetches and returns the rpms and images data for a specific release from the GitHub repository. The release corresponds to a branch in the repository.
+
+Request payload:
+
+release: The name of the release (branch in the repository).
+
+eg:
+
+Request: `http://art-dash-server-art-build-dev.apps.ocp4.prod.psi.redhat.com/api/v1/rpms-images-fetcher?release=openshift-4.11`
+
+Response:
+
+```json
+{
+    "status": "success",
+    "payload": [
+        {
+            "branch": "openshift-4.11",
+            "rpms_in_distgit": [...],
+            "images_in_distgit": [...]
+        }
+    ]
+}
+```


### PR DESCRIPTION
This PR updates the README.md to provide documentation for the newly added rpms-images-fetcher endpoint. The documentation covers the following:

- A brief explanation of what the endpoint does, which is fetching the rpms and images data for a specific release from the GitHub repository.
- How to use the endpoint: A GET request is sent to /api/v1/rpms-images-fetcher with the release name provided as a query parameter.
- An example request and the expected response format.
- The Python function fetch_data in the rpms_images_fetcher module that powers this endpoint.

