### PR TITLE
[ART-7959] Fix hotfixes not being reflected in dashboard

### DIFF
--- a/lib/http_requests.py
+++ b/lib/http_requests.py
@@ -193,7 +193,7 @@ def get_branch_advisory_ids(branch_name):
             try:
                 jira_link = advisory[2]
             except IndexError:
-                pass
+                jira_link = None  # Assign a default value
             advisory_data[advisory[0]] = [advisory[1], jira_link]
         return advisory_data
     return {"current": {}, "previous": {}}


### PR DESCRIPTION
Issue: The dashboard didn't correctly reflect hotfixes, as observed with the recent 4.12 release.

Resolution: The problem was due to the 'jira_link' variable being referenced before assignment. By ensuring that the variable has a default value, the issue was resolved.