### PR TITLE
Fix art-tools installation in dockerfiles

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -53,25 +53,21 @@ ENV PATH /home/"$USERNAME"/.local/bin:"$PATH"
 
 # Install art-dash and default configs
 COPY conf/krb5-redhat.conf /etc/krb5.conf
-COPY . /tmp/art-dash
-RUN cp /tmp/art-dash/container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml \
- && cp /tmp/art-dash/container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml \
- && rm -rf /tmp/art-dash
 
-# Only /workspaces has permissions for default user
-WORKDIR /workspaces
+COPY container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml
+COPY container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml
+
+WORKDIR /workspaces/art-dash
 
 USER "$USER_UID"
 # Clone art-tools and install
 RUN git clone https://github.com/openshift-eng/art-tools.git \
     && cd art-tools \
-    && ./install.sh \
-    && cd .. \
-    && rm -rf art-tools
+    && ./install.sh
 
 # Install dependencies from requirements.txt
 COPY requirements.txt ./
-RUN pip3 install --upgrade -r requirements.txt
+RUN pip3 install --upgrade -r requirements.txt \
+    && rm requirements.txt  # We need to manually remove since we copied using COPY
 
-WORKDIR /workspaces/art-dash
 EXPOSE 8080

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -47,7 +47,21 @@ RUN groupadd --gid "$USER_GID" "$USERNAME" \
     && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/"$USERNAME" \
     && chmod 0440 /etc/sudoers.d/"$USERNAME"
 
-WORKDIR /workspaces/art-dash
+# Setting HOME to dev user's and adding their bin to PATH
+ENV HOME /home/"$USERNAME"
+ENV PATH /home/"$USERNAME"/.local/bin:"$PATH"
+
+# Install art-dash and default configs
+COPY conf/krb5-redhat.conf /etc/krb5.conf
+COPY . /tmp/art-dash
+RUN cp /tmp/art-dash/container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml \
+ && cp /tmp/art-dash/container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml \
+ && rm -rf /tmp/art-dash
+
+# Only /workspaces has permissions for default user
+WORKDIR /workspaces
+
+USER "$USER_UID"
 # Clone art-tools and install
 RUN git clone https://github.com/openshift-eng/art-tools.git \
     && cd art-tools \
@@ -59,14 +73,5 @@ RUN git clone https://github.com/openshift-eng/art-tools.git \
 COPY requirements.txt ./
 RUN pip3 install --upgrade -r requirements.txt
 
-# Copy art-dash source and change ownership
-USER 0
-# Install art-dash and default configs
-COPY conf/krb5-redhat.conf /etc/krb5.conf
-COPY . /tmp/art-dash
-RUN cp /tmp/art-dash/container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml \
- && cp /tmp/art-dash/container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml \
- && rm -rf /tmp/art-dash
-
+WORKDIR /workspaces/art-dash
 EXPOSE 8080
-USER "$USER_UID"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -20,17 +20,16 @@ RUN cp /tmp/art-dash/container/doozer-settings.yaml /home/"$USERNAME"/.config/do
 # Switching back to default user
 USER "$USER_UID"
 
-WORKDIR /workspaces
+WORKDIR /workspaces/art-dash
 # Upadate pip
 RUN python3 -m pip install --upgrade pip
 COPY requirements.txt ./
-RUN pip3 install --upgrade -r requirements.txt
+RUN pip3 install --upgrade -r requirements.txt \
+    && rm requirements.txt  # We need to manually remove since we copied using COPY
 
-# Update art-tools and run the install script
+# Clone art-tools and install
 RUN cd art-tools \
     && git pull \
     && ./install.sh
-
-WORKDIR /workspaces/art-dash
 
 COPY . .

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,27 +3,34 @@ FROM art-dash-server:base
 # This build is meant to be based on an existing build and
 # update just doozer, elliott, and art-dash.
 
-# use same non-root user from the initial install
+# Use same non-root user from the initial install
 ARG USERNAME=dev
 # On Linux, replace with your actual UID, GID if not the default 1000
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
+# Since art-dash-server:base is set as dev user, we need to switch back to root
+USER 0
+# install default configs
+COPY . /tmp/art-dash
+RUN cp /tmp/art-dash/container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml \
+ && cp /tmp/art-dash/container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml \
+ && rm -rf /tmp/art-dash
+
+# Switching back to default user
+USER "$USER_UID"
+
+WORKDIR /workspaces
+# Upadate pip
+RUN python3 -m pip install --upgrade pip
+COPY requirements.txt ./
+RUN pip3 install --upgrade -r requirements.txt
+
+# Update art-tools and run the install script
+RUN cd art-tools \
+    && git pull \
+    && ./install.sh
+
+WORKDIR /workspaces/art-dash
 
 COPY . .
-
-# Switch to root user for git operations
-USER 0
-# Clone art-tools and run install.sh script
-RUN git clone https://github.com/openshift-eng/art-tools.git \
-    && cd art-tools \
-    && ./install.sh \
-    && cd .. \
-    && rm -rf art-tools
-
-# install default configs
-RUN cp ./container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml \
- && cp ./container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml \
- && cp ./conf/krb5-redhat.conf /etc/krb5.conf
-
-USER "$USER_UID"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,10 +12,8 @@ ARG USER_GID=$USER_UID
 # Since art-dash-server:base is set as dev user, we need to switch back to root
 USER 0
 # install default configs
-COPY . /tmp/art-dash
-RUN cp /tmp/art-dash/container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml \
- && cp /tmp/art-dash/container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml \
- && rm -rf /tmp/art-dash
+COPY container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml
+COPY container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml
 
 # Switching back to default user
 USER "$USER_UID"

--- a/Dockerfile.update
+++ b/Dockerfile.update
@@ -12,10 +12,8 @@ ARG USER_GID=$USER_UID
 # Since art-dash-server:base is set as dev user, we need to switch back to root
 USER 0
 # install default configs
-COPY . /tmp/art-dash
-RUN cp /tmp/art-dash/container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml \
- && cp /tmp/art-dash/container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml \
- && rm -rf /tmp/art-dash
+COPY container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml
+COPY container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml
 
 # Switching back to default user
 USER "$USER_UID"

--- a/Dockerfile.update
+++ b/Dockerfile.update
@@ -9,27 +9,31 @@ ARG USERNAME=dev
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-# Upadate pip
-RUN python3 -m pip install --upgrade pip
-
-# Update art-tools and run the install script
-RUN git clone https://github.com/openshift-eng/art-tools.git \
-    && cd art-tools \
-    && ./install.sh \
-    && cd .. \
-    && rm -rf art-tools  # Clone, update, install, and then remove art-tools
-
-COPY . .
-
-RUN pip3 install --upgrade -r requirements.txt
-
+# Since art-dash-server:base is set as dev user, we need to switch back to root
 USER 0
 # install default configs
-RUN cp ./container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml \
- && cp ./container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml \
- && cp ./conf/krb5-redhat.conf /etc/krb5.conf
+COPY . /tmp/art-dash
+RUN cp /tmp/art-dash/container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml \
+ && cp /tmp/art-dash/container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml \
+ && rm -rf /tmp/art-dash
 
+# Switching back to default user
 USER "$USER_UID"
+
+WORKDIR /workspaces
+# Upadate pip
+RUN python3 -m pip install --upgrade pip
+COPY requirements.txt ./
+RUN pip3 install --upgrade -r requirements.txt
+
+# Update art-tools and run the install script
+RUN cd art-tools \
+    && git pull \
+    && ./install.sh
+
+WORKDIR /workspaces/art-dash
+
+COPY . .
 
 # Start server
 CMD ["sh", "-c", "python3 manage.py makemigrations && python3 manage.py migrate && python3 manage.py runserver 0.0.0.0:8080 --noreload"]

--- a/Dockerfile.update
+++ b/Dockerfile.update
@@ -20,18 +20,17 @@ RUN cp /tmp/art-dash/container/doozer-settings.yaml /home/"$USERNAME"/.config/do
 # Switching back to default user
 USER "$USER_UID"
 
-WORKDIR /workspaces
+WORKDIR /workspaces/art-dash
 # Upadate pip
 RUN python3 -m pip install --upgrade pip
 COPY requirements.txt ./
-RUN pip3 install --upgrade -r requirements.txt
+RUN pip3 install --upgrade -r requirements.txt \
+    && rm requirements.txt  # We need to manually remove since we copied using COPY
 
-# Update art-tools and run the install script
+# Clone art-tools and install
 RUN cd art-tools \
     && git pull \
     && ./install.sh
-
-WORKDIR /workspaces/art-dash
 
 COPY . .
 


### PR DESCRIPTION
Changes in this PR:
- Installing packages as non root
- Not deleting art-tools dir post installation, since it won't work if we do
- Setting `HOME` and `PATH` values to satisfy pip during installs