### PR TITLE
upgrade script to use  pyton3

### DIFF
--- a/start-cmd.sh
+++ b/start-cmd.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 export RUN_ENV=development
-python manage.py makemigrations
-python manage.py migrate
-python manage.py runserver 0.0.0.0:8080 --noreload
+python3 manage.py makemigrations
+python3 manage.py migrate
+python3 manage.py runserver 0.0.0.0:8080 --noreload


### PR DESCRIPTION
in case the art-dashboard-server container runs in bash mode (needed i.e. if it is required to do a kinit inside the container) the script ./start-cmd.sh  has to be started. Since all Dockerfiles install or update python3 the script has to be updated to use the same version. If not the **python** is not recognized. 