### PR TITLE
ART-9026 add new api for check schedule

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -13,5 +13,8 @@ urlpatterns = [
     re_path('test', views.test),
     re_path('rpms_images_fetcher', views.rpms_images_fetcher_view),
     re_path('login', views.login_view, name='login'),
-    re_path('check_auth', views.check_auth, name='check_auth')
+    re_path('check_auth', views.check_auth, name='check_auth'),
+    re_path('advisory_activites', views.get_advisory_activities, name='advisory_activities'),
+    re_path('release_schedule', views.get_release_schedule, name='release_schedule'),
+    re_path('release_status', views.get_release_status, name='release_status')
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -205,25 +205,26 @@ def get_release_schedule(request):
 
 shipped_advisory = []
 
+
 @api_view(["GET"])
 def get_release_status(request):
     ga_version = get_ga_version()
     major, minor = int(ga_version.split('.')[0]), int(ga_version.split('.')[1])
-    status = {"message":[], "alert":[], "unshipped": []}
+    status = {"message": [], "alert": [], "unshipped": []}
     headers = {"Authorization": f"token {os.environ['GITHUB_PERSONAL_ACCESS_TOKEN']}"}
     for r in range(0, 4):
         version = minor - r
         advisory_schedule = get_advisory_schedule(f"{major}.{version}")['all_ga_tasks']
         for release in advisory_schedule:
-            if datetime.strptime(release['date_finish'],"%Y-%m-%d") < datetime.now():
+            if datetime.strptime(release['date_finish'], "%Y-%m-%d") < datetime.now():
                 release_date, release_name = release['date_finish'], release['name']
             else:
                 break
         if "GA" in release_name:
-            assembly = re.search(r'\d+\.\d+', release_name).group()+".0"
+            assembly = re.search(r'\d+\.\d+', release_name).group() + ".0"
         else:
             assembly = re.search(r'\d+\.\d+.\d+', release_name).group()
-        status['message'].append({"release":f"{major}.{version}", "status": f"{assembly} release date is {release_date} and {release['name']} release date is {release['date_finish']}"})
+        status['message'].append({"release": f"{major}.{version}", "status": f"{assembly} release date is {release_date} and {release['name']} release date is {release['date_finish']}"})
         res = requests.get(f"https://api.github.com/repos/openshift/ocp-build-data/contents/releases.yml?ref=openshift-{major}.{version}", headers=headers)
         release_assembly = yaml.safe_load(base64.b64decode(res.json()['content']))['releases'][assembly]['assembly']
         if "group" in release_assembly.keys():
@@ -234,9 +235,9 @@ def get_release_status(request):
             else:
                 advisories = {}
             for ad in advisories:
-                if datetime.strptime(release_date,"%Y-%m-%d").strftime("%Y-%m-%d") == datetime.now().strftime("%Y-%m-%d"):
+                if datetime.strptime(release_date, "%Y-%m-%d").strftime("%Y-%m-%d") == datetime.now().strftime("%Y-%m-%d"):
                     if advisories[ad] in shipped_advisory:
-                        status['alert'].append({"release":f"{major}.{version}", "status": f"{assembly} <https://errata.devel.redhat.com/advisory/{advisories[ad]}|{ad}> advisory is shipped live"})
+                        status['alert'].append({"release": f"{major}.{version}", "status": f"{assembly} <https://errata.devel.redhat.com/advisory/{advisories[ad]}|{ad}> advisory is shipped live"})
                     else:
                         errata_activity = get_advisory_status_activities(advisories[ad])['data']
                         if len(errata_activity) > 0:
@@ -245,11 +246,11 @@ def get_release_status(request):
                             errata_state = "NEW_FILES"
                         if errata_state == "SHIPPED_LIVE":
                             shipped_advisory.append(advisories[ad])
-                            status['alert'].append({"release":f"{major}.{version}", "status": f"{assembly} <https://errata.devel.redhat.com/advisory/{advisories[ad]}|{ad}> advisory is shipped live"})
+                            status['alert'].append({"release": f"{major}.{version}", "status": f"{assembly} <https://errata.devel.redhat.com/advisory/{advisories[ad]}|{ad}> advisory is shipped live"})
                         elif errata_state == "DROPPED_NO_SHIP":
-                            status['alert'].append({"release":f"{major}.{version}", "status": f"{assembly} <https://errata.devel.redhat.com/advisory/{advisories[ad]}|{ad}> advisory is dropped"})
+                            status['alert'].append({"release": f"{major}.{version}", "status": f"{assembly} <https://errata.devel.redhat.com/advisory/{advisories[ad]}|{ad}> advisory is dropped"})
                         else:
-                            status['alert'].append({"release":f"{major}.{version}", "status": f"{assembly} <https://errata.devel.redhat.com/advisory/{advisories[ad]}|{ad}> advisory is {errata_state}, release date is today"})
+                            status['alert'].append({"release": f"{major}.{version}", "status": f"{assembly} <https://errata.devel.redhat.com/advisory/{advisories[ad]}|{ad}> advisory is {errata_state}, release date is today"})
                             status['unshipped'].append({"advisory": advisories[ad], "note": f"{assembly} {ad} advisory"})
     return JsonResponse(status)
 

--- a/cron_tasks/Dockerfile
+++ b/cron_tasks/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.redhat.io/ubi9/ubi-minimal:latest
+RUN microdnf install -y python pip && python3 -m pip install --upgrade pip && pip3 install slack_sdk requests
+COPY check_schedule.py /check_schedule.py

--- a/cron_tasks/check_schedule.py
+++ b/cron_tasks/check_schedule.py
@@ -1,0 +1,40 @@
+import os
+import requests
+from typing import Optional
+import time
+from slack_sdk import WebClient
+
+slack_token = os.environ.get('SLACK_TOKEN', None)
+API_ENDPOINT = "https://art-dash-server-art-dashboard-server.apps.artc2023.pc3z.p1.openshiftapps.com/api/v1"
+
+def post_slack_message(message: str, thread_ts: Optional[str] = None,):
+    response = WebClient(token=slack_token).chat_postMessage(
+                channel="#forum-ocp-release",
+                text=message,
+                thread_ts=thread_ts, username="art-release-bot", link_names=True, attachments=[], icon_emoji=":dancing_robot:", reply_broadcast=False)
+    return response
+
+release_status = requests.get(f"{API_ENDPOINT}/release_status").json()
+if release_status['alert'] != []:
+    response = post_slack_message(' \n'.join([msg['status'] for msg in release_status['alert']]))
+    print(f"message posted in https://redhat-internal.slack.com/archives/{response['channel']}/p{response['ts'].replace('.', '')}")
+    if release_status['unshipped'] != []:
+        post_slack_message("start monitoring advisory not in shipped live status, interval set to 1 hour ...", thread_ts=response['ts'])
+        while release_status['unshipped'] != []:
+            for item in release_status['unshipped']:
+                # check ad status
+                advisory_status_response = requests.get(f"{API_ENDPOINT}/advisory_activites/?advisory={item['advisory']}").json()
+                errata_activity = advisory_status_response['data']
+                if len(errata_activity) > 0:
+                    advisory_status = errata_activity[-1]['attributes']['added']
+                else:
+                    advisory_status = "NEW_FILES"
+                if advisory_status == "SHIPPED_LIVE" or advisory_status == "DROPPED_NO_SHIP":
+                    release_status['unshipped'].remove(item)
+                    post_slack_message(f"{item['note']} status changed to {advisory_status}", thread_ts=response['ts'])
+            # sleep 1 hours
+            print(f"sleeping 1 hours due to {release_status['unshipped']}")
+            time.sleep(3600)
+        post_slack_message("All advisory now in shipped live status, stop monitoring", thread_ts=response['ts'])
+else:
+    print("No alert", [msg['status'] for msg in release_status['message']])

--- a/cron_tasks/check_schedule.py
+++ b/cron_tasks/check_schedule.py
@@ -7,12 +7,14 @@ from slack_sdk import WebClient
 slack_token = os.environ.get('SLACK_TOKEN', None)
 API_ENDPOINT = "https://art-dash-server-art-dashboard-server.apps.artc2023.pc3z.p1.openshiftapps.com/api/v1"
 
+
 def post_slack_message(message: str, thread_ts: Optional[str] = None,):
     response = WebClient(token=slack_token).chat_postMessage(
                 channel="#forum-ocp-release",
                 text=message,
                 thread_ts=thread_ts, username="art-release-bot", link_names=True, attachments=[], icon_emoji=":dancing_robot:", reply_broadcast=False)
     return response
+
 
 release_status = requests.get(f"{API_ENDPOINT}/release_status").json()
 if release_status['alert'] != []:

--- a/lib/errata/errata_requests.py
+++ b/lib/errata/errata_requests.py
@@ -9,6 +9,7 @@ import ssl
 
 PP_SERVER = "https://pp.engineering.redhat.com/api/v7/releases"
 
+
 @update_keytab
 def get_advisory_data(advisory_id):
     """


### PR DESCRIPTION
Add 3 api in art-dashboard-server used for check schedule
* /advisory_activites
   this API will get advisory status, used for monitor advisory moved to shipped status
* /release_schedule
  this API will get release schedule of a release version, used for determine release date
* /release_status
  this API will get overall release status used for report summary for alert message