### PR TITLE
Fix advisory inheritance and overrides

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -60,6 +60,11 @@ COPY container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.
 WORKDIR /workspaces/art-dash
 
 USER "$USER_UID"
+
+#Setup uv package manager
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/home/$USERNAME/.local" sh \
+    && uv venv --python 3.11 ../.venv
+
 # Clone art-tools and install
 RUN git clone https://github.com/openshift-eng/art-tools.git \
     && cd art-tools \
@@ -67,7 +72,7 @@ RUN git clone https://github.com/openshift-eng/art-tools.git \
 
 # Install dependencies from requirements.txt
 COPY requirements.txt ./
-RUN pip3 install --upgrade -r requirements.txt \
+RUN uv pip install --upgrade -r requirements.txt \
     && rm requirements.txt
 
 EXPOSE 8080

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,10 +19,12 @@ COPY container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.
 USER "$USER_UID"
 
 WORKDIR /workspaces/art-dash
-# Upadate pip
-RUN python3 -m pip install --upgrade pip
+
+# Update uv
+RUN uv self update
+
 COPY requirements.txt ./
-RUN pip3 install --upgrade -r requirements.txt \
+RUN uv pip install --upgrade -r requirements.txt \
     && rm requirements.txt  # We need to manually remove since we copied using COPY
 
 # Clone art-tools and install

--- a/Dockerfile.update
+++ b/Dockerfile.update
@@ -19,10 +19,12 @@ COPY container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.
 USER "$USER_UID"
 
 WORKDIR /workspaces/art-dash
-# Upadate pip
-RUN python3 -m pip install --upgrade pip
+
+# Update uv
+RUN uv self update
+
 COPY requirements.txt ./
-RUN pip3 install --upgrade -r requirements.txt \
+RUN uv pip install --upgrade -r requirements.txt \
     && rm requirements.txt  # We need to manually remove since we copied using COPY
 
 # Clone art-tools and install
@@ -33,4 +35,4 @@ RUN cd art-tools \
 COPY . .
 
 # Start server
-CMD ["sh", "-c", "python3 manage.py makemigrations && python3 manage.py migrate && python3 manage.py runserver 0.0.0.0:8080 --noreload"]
+CMD ["sh", "-c", "source ../.venv/bin/activate && python3 manage.py makemigrations && python3 manage.py migrate && python3 manage.py runserver 0.0.0.0:8080 --noreload"]


### PR DESCRIPTION
Fixes the following:
1. Previously, when retrieving advisory IDs of a release which had `advisories!` defined, art-dash would use the `advisories` defined in the basis version (it would also not retrieve the corresponding jira ticket)
2. When merging `current_advisories` and `basis_advisories` (or `basis_override_advisories`), art-dash would layer `basis_advisories` (or `basis_override_advisories`) over `current_advisories`. Now it is the opposite.

~~Also temporarily replace `./install.sh` in the Dockerfiles with `pip3 install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/` because `./install.sh` is now using `uv` package manager and so far I couldn't get it to work inside the Dockerfiles.~~ This is now fixed