### PR TITLE
use pip3 instead of uv

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -63,7 +63,7 @@ USER "$USER_UID"
 # Clone art-tools and install
 RUN git clone https://github.com/openshift-eng/art-tools.git \
     && cd art-tools \
-    && ./install.sh
+    && pip3 install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
 
 # Install dependencies from requirements.txt
 COPY requirements.txt ./

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -28,6 +28,6 @@ RUN pip3 install --upgrade -r requirements.txt \
 # Clone art-tools and install
 RUN cd art-tools \
     && git pull \
-    && ./install.sh
+    && pip3 install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
 
 COPY . .

--- a/Dockerfile.update
+++ b/Dockerfile.update
@@ -28,7 +28,7 @@ RUN pip3 install --upgrade -r requirements.txt \
 # Clone art-tools and install
 RUN cd art-tools \
     && git pull \
-    && ./install.sh
+    && pip3 install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
 
 COPY . .
 


### PR DESCRIPTION
art-tools `./install.sh` has moved to using a new tool called `uv` for `pip install`. `uv` requires a virtual environment to be setup, but in openshift, since all runs are independent (in different pods), we do not need a virtual environment, and installs can be global.

The increased install times by pip during builds is circumvented by a multi later Docker build (using two Dockerfile) so using `uv` does not have clear benefit on Openshift. 