### PR TITLE
Bump asgiref to 3.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-asgiref==3.5.2
+asgiref==3.6.0
 boto3==1.26.104
 botocore==1.29.104
 cachetools==5.2.0


### PR DESCRIPTION
Bump `asgiref` to `3.6.0` so that https://github.com/openshift-eng/art-dashboard-server/pull/151 can be merged (Django version `4.2.16` requires `asgiref>=3.6.0`)