### PR TITLE
ART-19085: Optimize errata data retrieval performance

### DIFF
--- a/errata/request_dispatchers/advisory.py
+++ b/errata/request_dispatchers/advisory.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from lib.errata.errata_requests import get_advisory_data
 
 
@@ -44,4 +45,35 @@ def route_advisory_get(request_param):
 
     if request_param["type"] == "advisory":
         data = get_advisory_data(request_param["id"])
+        if isinstance(data, dict) and "error" in data:
+            return {"status": "error", "message": data["message"], "data": None}
         return {"status": "success", "message": "Data is ready.", "data": data}
+
+
+def validate_batch_advisory_get(request):
+    ids_param = request.query_params.get("ids", None)
+    if not ids_param:
+        return False, {"status": "error", "message": "Missing 'ids' query param.", "data": []}
+
+    advisory_ids = [aid.strip() for aid in ids_param.split(",") if aid.strip()]
+    if not advisory_ids:
+        return False, {"status": "error", "message": "No valid advisory IDs provided.", "data": []}
+
+    return True, {"ids": advisory_ids}
+
+
+def route_batch_advisory_get(request_param):
+    advisory_ids = request_param["ids"]
+    results = {}
+
+    with ThreadPoolExecutor(max_workers=min(len(advisory_ids), 8)) as pool:
+        futures = {pool.submit(get_advisory_data, aid): aid for aid in advisory_ids}
+        for future in as_completed(futures):
+            aid = futures[future]
+            data = future.result()
+            if isinstance(data, dict) and "error" in data:
+                results[aid] = {"status": "error", "message": data["message"], "data": None}
+            else:
+                results[aid] = {"status": "success", "message": "Data is ready.", "data": data}
+
+    return {"status": "success", "message": "Batch data is ready.", "data": results}

--- a/errata/urls.py
+++ b/errata/urls.py
@@ -1,8 +1,10 @@
 from django.urls import re_path
 from .views.advisory import Advisory
+from .views.batch_advisory import BatchAdvisory
 from .views.user import User
 
 urlpatterns = [
+    re_path('advisory/batch/', BatchAdvisory.as_view(), name='errata_batch_advisory_view'),
     re_path('advisory/', Advisory.as_view(), name='errata_advisory_view'),
     re_path('user/', User.as_view(), name='errata_user_view')
 ]

--- a/errata/views/batch_advisory.py
+++ b/errata/views/batch_advisory.py
@@ -1,0 +1,16 @@
+from rest_framework import generics
+from errata.request_dispatchers.advisory import validate_batch_advisory_get, route_batch_advisory_get
+from rest_framework.response import Response
+
+
+class BatchAdvisory(generics.ListAPIView):
+
+    def get(self, request, *args, **kwargs):
+
+        validation_status, result = validate_batch_advisory_get(request)
+
+        if validation_status:
+            response = route_batch_advisory_get(result)
+            return Response(data=response)
+        else:
+            return Response(data=result)

--- a/lib/errata/decorators.py
+++ b/lib/errata/decorators.py
@@ -1,11 +1,22 @@
 from api.kerberos import do_kinit
 import functools
+import time
+import threading
+
+_last_kinit = 0.0
+_kinit_lock = threading.Lock()
+KINIT_INTERVAL_SECONDS = 60
 
 
 def update_keytab(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        do_kinit()
-        func_ret = func(*args, **kwargs)
-        return func_ret
+        global _last_kinit
+        now = time.monotonic()
+        if now - _last_kinit >= KINIT_INTERVAL_SECONDS:
+            with _kinit_lock:
+                if now - _last_kinit >= KINIT_INTERVAL_SECONDS:
+                    do_kinit()
+                    _last_kinit = time.monotonic()
+        return func(*args, **kwargs)
     return wrapper

--- a/lib/errata/errata_requests.py
+++ b/lib/errata/errata_requests.py
@@ -1,11 +1,26 @@
 import os
 import requests
-import json
-from requests_kerberos import HTTPKerberosAuth, OPTIONAL
-from .decorators import update_keytab
-from urllib.parse import urlparse
-from requests_gssapi import HTTPSPNEGOAuth
+import logging
 import ssl
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.parse import urlparse
+
+from requests_gssapi import HTTPSPNEGOAuth
+from .decorators import update_keytab
+
+logger = logging.getLogger(__name__)
+
+HTTP_TIMEOUT = (5, 30)
+
+
+def _errata_get(url):
+    """Shared helper for authenticated GET with timeout."""
+    return requests.get(
+        urlparse(url).geturl(),
+        verify=ssl.get_default_verify_paths().openssl_cafile,
+        auth=HTTPSPNEGOAuth(),
+        timeout=HTTP_TIMEOUT,
+    )
 
 
 @update_keytab
@@ -13,44 +28,75 @@ def get_advisory_data(advisory_id):
     """
     This method returns advisory data for a given id.
     :param advisory_id: The id of the advisory to get data for.
-    :return: Dict, advisory data.
+    :return: Dict with advisory data, or dict with 'error' key on failure.
     """
 
     try:
-        errata_endpoint = os.environ["ERRATA_ADVISORY_ENDPOINT"]
-        jira_issues_endpoint = f"{os.environ['ERRATA_SERVER']}/advisory/{advisory_id}/jira_issues.json"
-        response = requests.get(urlparse(errata_endpoint.format(advisory_id)).geturl(), verify=ssl.get_default_verify_paths().openssl_cafile, auth=HTTPSPNEGOAuth())
+        errata_url = os.environ["ERRATA_ADVISORY_ENDPOINT"].format(advisory_id)
+        jira_url = f"{os.environ['ERRATA_SERVER']}/advisory/{advisory_id}/jira_issues.json"
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            future_advisory = pool.submit(_errata_get, errata_url)
+            future_jira = pool.submit(_errata_get, jira_url)
+
+            response = future_advisory.result()
+            jira_response = future_jira.result()
+
         if response.status_code != 200:
-            return None
-        advisory_data = json.loads(response.text)
-        jira_response = requests.get(
-            urlparse(jira_issues_endpoint).geturl(),
-            verify=ssl.get_default_verify_paths().openssl_cafile,
-            auth=HTTPSPNEGOAuth()
-        )
-        jira_issues_data = json.loads(jira_response.text)
+            logger.warning("Errata API returned %s for advisory %s", response.status_code, advisory_id)
+            return {
+                "error": "errata_api_error",
+                "message": f"Errata API returned HTTP {response.status_code}",
+                "advisory_id": advisory_id,
+            }
+
+        advisory_data = response.json()
+
+        jira_issues_data = None
+        if jira_response.status_code == 200:
+            jira_issues_data = jira_response.json()
+        else:
+            logger.warning("Jira issues endpoint returned %s for advisory %s", jira_response.status_code, advisory_id)
 
         return format_advisory_data(advisory_data, jira_issues_data)
 
+    except requests.exceptions.Timeout:
+        logger.exception("Timeout fetching advisory %s", advisory_id)
+        return {
+            "error": "timeout",
+            "message": "Errata request timed out",
+            "advisory_id": advisory_id,
+        }
+    except requests.exceptions.ConnectionError:
+        logger.exception("Connection error fetching advisory %s", advisory_id)
+        return {
+            "error": "connection_error",
+            "message": "Could not connect to Errata server",
+            "advisory_id": advisory_id,
+        }
     except Exception:
-        return None
+        logger.exception("Unexpected error fetching advisory %s", advisory_id)
+        return {
+            "error": "unknown",
+            "message": "An unexpected error occurred while fetching advisory data",
+            "advisory_id": advisory_id,
+        }
 
 
-@update_keytab
 def get_user_data(user_id):
     """
-        This method returns user data for a given id.
-        :param user_id: The id of the user to get data for.
-        :return: Dict, user data.
-        """
+    This method returns user data for a given id.
+    Called from within get_advisory_data which already holds a valid Kerberos ticket.
+    :param user_id: The id of the user to get data for.
+    :return: Dict, user data.
+    """
 
     try:
         errata_endpoint = os.environ["ERRATA_USER_ENDPOINT"]
-
-        response = requests.get(urlparse(errata_endpoint.format(user_id)).geturl(), verify=ssl.get_default_verify_paths().openssl_cafile, auth=HTTPSPNEGOAuth())
-        return format_user_data(json.loads(response.text))
-    except Exception as e:
-        print(e)
+        response = _errata_get(errata_endpoint.format(user_id))
+        return format_user_data(response.json())
+    except Exception:
+        logger.exception("Error fetching user data for user %s", user_id)
         return None
 
 
@@ -138,36 +184,28 @@ def format_advisory_data(advisory_data, jira_issues_data):
                 advisory_detail["security_approved"] = "Unknown"
 
             if "content" in advisory_data and "content" in advisory_data["content"]:
+                content = advisory_data["content"]["content"]
                 qe_reviewer_id = None
+                doc_reviewer_id = content.get("doc_reviewer_id")
+                product_security_reviewer_id = content.get("product_security_reviewer_id")
 
-                doc_reviewer_id = advisory_data["content"]["content"]["doc_reviewer_id"] \
-                    if "doc_reviewer_id" in advisory_data["content"]["content"] \
-                    else None
+                reviewer_ids = {
+                    "qe_reviewer": qe_reviewer_id,
+                    "doc_reviewer": doc_reviewer_id,
+                    "product_security_reviewer": product_security_reviewer_id,
+                }
+                reviewer_details = {k: None for k in reviewer_ids}
 
-                product_security_reviewer_id = advisory_data["content"]["content"]["product_security_reviewer_id"] \
-                    if "product_security_reviewer_id" in advisory_data["content"]["content"] \
-                    else None
+                ids_to_fetch = {k: v for k, v in reviewer_ids.items() if v is not None}
+                if ids_to_fetch:
+                    with ThreadPoolExecutor(max_workers=len(ids_to_fetch)) as pool:
+                        futures = {pool.submit(get_user_data, uid): role for role, uid in ids_to_fetch.items()}
+                        for future in as_completed(futures):
+                            reviewer_details[futures[future]] = future.result()
 
-                advisory_detail["qe_reviewer_id"] = qe_reviewer_id
-
-                if qe_reviewer_id is not None:
-                    advisory_detail["qe_reviewer_details"] = get_user_data(qe_reviewer_id)
-                else:
-                    advisory_detail["qe_reviewer_details"] = None
-
-                advisory_detail["doc_reviewer_id"] = doc_reviewer_id
-
-                if doc_reviewer_id is not None:
-                    advisory_detail["doc_reviewer_details"] = get_user_data(doc_reviewer_id)
-                else:
-                    advisory_detail["doc_reviewer_details"] = None
-
-                advisory_detail["product_security_reviewer_id"] = product_security_reviewer_id
-
-                if product_security_reviewer_id is not None:
-                    advisory_detail["product_security_reviewer_details"] = get_user_data(product_security_reviewer_id)
-                else:
-                    advisory_detail["product_security_reviewer_details"] = None
+                for role, uid in reviewer_ids.items():
+                    advisory_detail[f"{role}_id"] = uid
+                    advisory_detail[f"{role}_details"] = reviewer_details[role]
 
             advisory_details.append(advisory_detail)
 


### PR DESCRIPTION
## Summary
- Parallelize advisory + Jira issues fetches and reviewer user lookups using `ThreadPoolExecutor`, reducing 4 sequential HTTP round-trips to 2 parallel batches per advisory
- Add 60-second time-guard to the `kinit` decorator to avoid redundant Kerberos subprocess calls on every request
- Add HTTP timeouts `(5s connect, 30s read)` to all Errata API requests to prevent indefinite worker hangs
- Replace silent `except Exception: return None` with structured error responses (`{"error": "timeout", "message": ...}`) and `logger.exception()` logging
- Add batch advisory endpoint `GET /errata/advisory/batch/?ids=123,456,789` that fetches multiple advisories in parallel in a single request, eliminating N+1 round-trips from the frontend

## Test plan
- [x] Single advisory endpoint (`GET /errata/advisory/?type=advisory&id=167211`) returns correct data with full reviewer details
- [x] Batch endpoint (`GET /errata/advisory/batch/?ids=167211,167213`) returns keyed results for both advisories
- [x] Error responses include `"status": "error"` with human-readable messages (tested via non-200 status codes)
- [x] Backend starts without import errors
- [ ] Verify on staging with VPN + Kerberos that advisory data renders correctly in the dashboard
- [ ] Verify timeout behavior by temporarily setting `HTTP_TIMEOUT` to a very low value


Made with [Cursor](https://cursor.com)