### PR TITLE
Fix art-tools install after upstream packaging restructure

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -61,7 +61,7 @@ USER "$USER_UID"
 # Clone art-tools and install
 RUN git clone https://github.com/openshift-eng/art-tools.git \
     && cd art-tools \
-    && pip3 install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
+    && pip3 install -e .
 
 # Install dependencies from requirements.txt
 COPY requirements.txt ./

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -28,6 +28,6 @@ RUN pip3 install --upgrade -r requirements.txt \
 # Clone art-tools and install
 RUN cd art-tools \
     && git pull \
-    && pip3 install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
+    && pip3 install -e .
 
 COPY . .

--- a/Dockerfile.update
+++ b/Dockerfile.update
@@ -40,7 +40,7 @@ RUN pip3 install --upgrade -r requirements.txt \
 # Clone art-tools and install
 RUN cd art-tools \
     && git pull \
-    && pip3 install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
+    && pip3 install -e .
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- Upstream `art-tools` moved from per-package `setup.py` files to a single root-level `pyproject.toml` (the individual `artcommon/setup.py`, `doozer/setup.py`, etc. were removed)
- All three Dockerfiles (base, update, dev) still used `pip3 install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/` which now fails with "does not appear to be a Python project"
- Replace with `pip3 install -e .` from the art-tools root directory

Fixes build #92 failure.

## Test plan
- [ ] Trigger a rebuild and verify the container image builds successfully


Made with [Cursor](https://cursor.com)