### PR TITLE
Add shipment advisory status from GitLab MRs

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     re_path(r'', include(router.urls)),
     re_path('pipeline-image', views.pipeline_from_github_api_endpoint),
     re_path('ga-version', views.ga_version),
+    re_path('shipment/status/', views.shipment_status, name='shipment_status'),
     re_path('branch/', views.branch_data, name='branch_data_view'),
     re_path('test', views.test),
     re_path('git_jira_api', views.git_jira_api),

--- a/api/views.py
+++ b/api/views.py
@@ -5,6 +5,7 @@ from rest_framework.decorators import api_view, permission_classes, authenticati
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from api.fetchers import rpms_images_fetcher
+from lib.gitlab_requests import get_shipment_status
 from api.image_pipeline import pipeline_image_names
 from api.util import get_ga_version
 from build.models import Build
@@ -516,6 +517,28 @@ def rpms_images_fetcher_view(request):
         "status": "success",
         "payload": result
     }, status=200)
+
+
+@api_view(["GET"])
+def shipment_status(request):
+    mr_url = request.query_params.get("url", None)
+    branch = request.query_params.get("branch", None)
+    assembly = request.query_params.get("assembly", None)
+
+    if not all([mr_url, branch, assembly]):
+        return Response(
+            data={"status": "error", "message": "Missing required params: url, branch, assembly"},
+            status=400
+        )
+
+    try:
+        result = get_shipment_status(mr_url, branch, assembly)
+        return Response(data=result)
+    except Exception as e:
+        return Response(
+            data={"status": "error", "message": str(e)},
+            status=500
+        )
 
 
 @api_view(["POST"])

--- a/conf/common.env
+++ b/conf/common.env
@@ -15,3 +15,7 @@ ERRATA_USER_ENDPOINT=https://errata.devel.redhat.com/api/v1/user/{}
 
 # errata server api
 ERRATA_SERVER=https://errata.devel.redhat.com
+
+# gitlab api for shipment MR status
+GITLAB_API_URL=https://gitlab.cee.redhat.com/api/v4
+GITLAB_API_TOKEN=

--- a/lib/gitlab_requests.py
+++ b/lib/gitlab_requests.py
@@ -1,0 +1,154 @@
+import os
+import re
+import yaml
+import base64
+import logging
+import requests
+from urllib.parse import quote_plus
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+logger = logging.getLogger(__name__)
+
+GITLAB_API_URL = "https://gitlab.cee.redhat.com/api/v4"
+
+
+def _get_gitlab_headers():
+    token = os.environ.get("GITLAB_API_TOKEN", "")
+    return {"PRIVATE-TOKEN": token}
+
+
+def _parse_mr_url(mr_url):
+    """Parse a GitLab MR URL into project path and MR IID."""
+    match = re.match(r'https?://[^/]+/(.+?)/-/merge_requests/(\d+)', mr_url)
+    if not match:
+        return None, None
+    return match.group(1), int(match.group(2))
+
+
+def _gitlab_get(endpoint):
+    url = f"{GITLAB_API_URL}/{endpoint}"
+    response = requests.get(url, headers=_get_gitlab_headers(), timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+def _get_mr_metadata(project_encoded, iid):
+    return _gitlab_get(f"projects/{project_encoded}/merge_requests/{iid}")
+
+
+def _get_mr_approval_state(project_encoded, iid):
+    return _gitlab_get(f"projects/{project_encoded}/merge_requests/{iid}/approval_state")
+
+
+def _get_file_content(project_encoded, file_path_encoded, ref):
+    data = _gitlab_get(f"projects/{project_encoded}/repository/files/{file_path_encoded}?ref={ref}")
+    content = base64.b64decode(data["content"]).decode("utf-8")
+    return yaml.safe_load(content)
+
+
+def _parse_shipment_file(parsed_yaml):
+    """Extract advisory data from a parsed shipment YAML file."""
+    shipment = parsed_yaml.get("shipment", {})
+    release_notes = shipment.get("data", {}).get("releaseNotes", {})
+    environments = shipment.get("environments", {})
+
+    stage_advisory = environments.get("stage", {}).get("advisory", {})
+    prod_advisory = environments.get("prod", {}).get("advisory", {})
+
+    return {
+        "type": release_notes.get("type"),
+        "live_id": release_notes.get("live_id"),
+        "synopsis": release_notes.get("synopsis", ""),
+        "stage_url": stage_advisory.get("url"),
+        "prod_url": prod_advisory.get("url"),
+    }
+
+
+def _determine_status(labels):
+    if "prod-release-success" in labels:
+        return "SHIPPED_LIVE"
+    elif "stage-release-success" in labels:
+        return "Staged"
+    return "Pending"
+
+
+def get_shipment_status(mr_url, branch, assembly):
+    """
+    Get shipment advisory status from a GitLab MR.
+
+    Returns dict with status, approvals, and per-kind advisory data.
+    """
+    project_path, iid = _parse_mr_url(mr_url)
+    if not project_path or not iid:
+        return {"error": f"Could not parse MR URL: {mr_url}"}
+
+    project_encoded = quote_plus(project_path)
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            future_mr = pool.submit(_get_mr_metadata, project_encoded, iid)
+            future_approvals = pool.submit(_get_mr_approval_state, project_encoded, iid)
+
+            mr_data = future_mr.result()
+            approval_data = future_approvals.result()
+    except Exception as e:
+        logger.error(f"Error fetching MR metadata for {mr_url}: {e}")
+        return {"error": str(e)}
+
+    labels = mr_data.get("labels", [])
+    source_branch = mr_data.get("source_branch", "")
+    state = mr_data.get("state", "")
+
+    status = _determine_status(labels)
+
+    approvals = {}
+    for rule in approval_data.get("rules", []):
+        rule_name = rule.get("name", "")
+        approved_by_list = rule.get("approved_by", [])
+        approver_name = approved_by_list[0].get("name", "") if approved_by_list else ""
+        approvals[rule_name] = {
+            "approved": rule.get("approved", False),
+            "approved_by": approver_name,
+        }
+
+    ref = "main" if state == "merged" else source_branch
+    timestamp_match = re.match(r'prepare-shipment-.+-(\d+)$', source_branch)
+    if not timestamp_match:
+        return {
+            "status": status,
+            "mr_url": mr_url,
+            "approvals": approvals,
+            "advisories": {},
+        }
+    timestamp = timestamp_match.group(1)
+
+    app = branch.replace(".", "-")
+    kinds = ["image", "extras", "metadata"]
+
+    def fetch_kind(kind):
+        file_path = f"shipment/ocp/{branch}/{app}/prod/{assembly}.{kind}.{timestamp}.yaml"
+        file_path_encoded = quote_plus(file_path)
+        try:
+            parsed = _get_file_content(project_encoded, file_path_encoded, ref)
+            return kind, _parse_shipment_file(parsed)
+        except Exception as e:
+            logger.warning(f"Could not read shipment file for {kind}: {e}")
+            return kind, None
+
+    advisories = {}
+    try:
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = [pool.submit(fetch_kind, k) for k in kinds]
+            for future in as_completed(futures):
+                kind, data = future.result()
+                if data:
+                    advisories[kind] = data
+    except Exception as e:
+        logger.error(f"Error fetching shipment files: {e}")
+
+    return {
+        "status": status,
+        "mr_url": mr_url,
+        "approvals": approvals,
+        "advisories": advisories,
+    }

--- a/lib/http_requests.py
+++ b/lib/http_requests.py
@@ -226,7 +226,9 @@ def get_advisories(branch_name):
         group_data = _assembly_field("group", yml_data, version)
         advisories = group_data.get("advisories", {})
         jira_link = group_data.get("release_jira", "")
-        advisory_data.append([version, advisories, jira_link])
+        shipment = group_data.get("shipment", {})
+        release_date = group_data.get("release_date", "")
+        advisory_data.append([version, advisories, jira_link, shipment, release_date])
 
     return advisory_data
 
@@ -244,8 +246,28 @@ def get_branch_advisory_ids(branch_name):
                 try:
                     jira_link = advisory[2]
                 except IndexError:
-                    jira_link = None  # Assign a default value
-                advisory_data[advisory[0]] = [advisory[1], jira_link]
+                    jira_link = None
+                try:
+                    shipment_raw = advisory[3]
+                    release_date = advisory[4]
+                except IndexError:
+                    shipment_raw = {}
+                    release_date = ""
+                shipment_info = {}
+                if shipment_raw:
+                    shipment_advisories = []
+                    for a in shipment_raw.get("advisories", []):
+                        if a.get("kind") in ("image", "extras", "metadata"):
+                            shipment_advisories.append({
+                                "kind": a["kind"],
+                                "live_id": a.get("live_id")
+                            })
+                    shipment_info = {
+                        "url": shipment_raw.get("url", ""),
+                        "release_date": release_date,
+                        "advisories": shipment_advisories
+                    }
+                advisory_data[advisory[0]] = [advisory[1], jira_link, shipment_info]
         if not advisories:  # If advisories is None or empty
             return {"current": {}, "previous": {}}  # Return empty data structure
 


### PR DESCRIPTION
## Summary
- Extract shipment advisory data (`image`, `extras`, `metadata`) and `release_date` from `releases.yml` alongside existing errata advisory IDs
- Add `lib/gitlab_requests.py` to fetch MR metadata (labels for stage/prod status), approval state (ART/ERT/Docs), and individual advisory YAML files (type, URLs, synopsis) from `gitlab.cee.redhat.com`
- New endpoint `GET /api/v1/shipment/status/` that returns combined status, approvals, and per-kind advisory data for a shipment MR

## Test plan
- [ ] Verify `GET /api/v1/release/branch/?type=openshift_branch_advisory_ids&branch=openshift-4.21` includes `shipment` data as third element per version
- [ ] Verify `GET /api/v1/shipment/status/?url=<mr_url>&branch=<branch>&assembly=<version>` returns correct status (`Pending`/`Staged`/`SHIPPED_LIVE`), approvals, and advisory URLs
- [ ] Test with a merged MR (e.g., MR 533) to confirm `SHIPPED_LIVE` status and prod URLs
- [ ] Test with an open MR (e.g., MR 545) to confirm `Pending` status
- [ ] Ensure `GITLAB_API_TOKEN` env var is set for GitLab API access


Made with [Cursor](https://cursor.com)