### PR TITLE
ART-19365: Extract and return pipeline status from releases.yml

### DIFF
--- a/lib/http_requests.py
+++ b/lib/http_requests.py
@@ -228,7 +228,8 @@ def get_advisories(branch_name):
         jira_link = group_data.get("release_jira", "")
         shipment = group_data.get("shipment", {})
         release_date = group_data.get("release_date", "")
-        advisory_data.append([version, advisories, jira_link, shipment, release_date])
+        status = yml_data["releases"][version].get("status", {})
+        advisory_data.append([version, advisories, jira_link, shipment, release_date, status])
 
     return advisory_data
 
@@ -267,7 +268,8 @@ def get_branch_advisory_ids(branch_name):
                         "release_date": release_date,
                         "advisories": shipment_advisories
                     }
-                advisory_data[advisory[0]] = [advisory[1], jira_link, shipment_info]
+                status_data = advisory[5] if len(advisory) > 5 else {}
+                advisory_data[advisory[0]] = [advisory[1], jira_link, shipment_info, status_data]
         if not advisories:  # If advisories is None or empty
             return {"current": {}, "previous": {}}  # Return empty data structure
 


### PR DESCRIPTION
## Summary
- Extract `status` field from each release entry in `get_advisories()`
- Pass status through `get_branch_advisory_ids()` as 4th element in the response
- Defaults to empty dict when no status field exists (backwards compatible)

## Context
Companion to the art-tools PR that adds pipeline job completion status fields to releases.yml. The dashboard backend now extracts and forwards these fields to the frontend.

## Test plan
- [ ] Test `get_advisories()` with mock YAML containing `status` -- verify extraction
- [ ] Test `get_branch_advisory_ids()` returns status as 4th element
- [ ] Test backwards compat with YAML missing `status` field -- should default to `{}`

Generated with [Claude Code](https://claude.com/claude-code)